### PR TITLE
Suggestion to add support for ClientCertificates on Ssl Authentication

### DIFF
--- a/Tcp.NET.Client/Handlers/TcpClientHandlerBase.cs
+++ b/Tcp.NET.Client/Handlers/TcpClientHandlerBase.cs
@@ -385,7 +385,8 @@ namespace Tcp.NET.Client.Handlers
 
             await sslStream.AuthenticateAsClientAsync(new SslClientAuthenticationOptions
             {
-                TargetHost = _parameters.Host
+                TargetHost = _parameters.Host,
+                ClientCertificates = _parameters.ClientCertificates,
             }, cancellationToken).ConfigureAwait(false);
 
             if (sslStream.IsAuthenticated && sslStream.IsEncrypted && !cancellationToken.IsCancellationRequested)

--- a/Tcp.NET.Client/Models/IParamsTcpClient.cs
+++ b/Tcp.NET.Client/Models/IParamsTcpClient.cs
@@ -1,4 +1,5 @@
 ﻿using PHS.Networking.Models;
+using System.Security.Cryptography.X509Certificates;
 
 namespace Tcp.NET.Client.Models
 {
@@ -15,5 +16,6 @@ namespace Tcp.NET.Client.Models
         byte[] Token { get; }
         bool UseDisconnectBytes { get; }
         bool UsePingPong { get; }
+        X509CertificateCollection ClientCertificates { get; }
     }
 }

--- a/Tcp.NET.Client/Models/ParamsTcpClient.cs
+++ b/Tcp.NET.Client/Models/ParamsTcpClient.cs
@@ -1,5 +1,6 @@
 ﻿using PHS.Networking.Utilities;
 using System;
+using System.Security.Cryptography.X509Certificates;
 using System.Text;
 
 namespace Tcp.NET.Client.Models
@@ -17,8 +18,9 @@ namespace Tcp.NET.Client.Models
         public byte[] Token { get; protected set; }
         public bool UseDisconnectBytes { get; protected set; }
         public byte[] DisconnectBytes { get; protected set; }
+        public X509CertificateCollection ClientCertificates { get; protected set; }
 
-        public ParamsTcpClient(string host, int port, string endOfLineCharacters, string token = "", bool isSSL = true, bool onlyEmitBytes = false, bool usePingPong = true, string pingCharacters = "ping", string pongCharacters = "pong", bool useDisconnectBytes = true, byte[] disconnectBytes = null)
+        public ParamsTcpClient(string host, int port, string endOfLineCharacters, string token = "", bool isSSL = true, bool onlyEmitBytes = false, bool usePingPong = true, string pingCharacters = "ping", string pongCharacters = "pong", bool useDisconnectBytes = true, byte[] disconnectBytes = null, X509CertificateCollection clientCertificates = null)
         {
             if (string.IsNullOrWhiteSpace(host))
             {
@@ -55,6 +57,7 @@ namespace Tcp.NET.Client.Models
             OnlyEmitBytes = onlyEmitBytes;
             UseDisconnectBytes = useDisconnectBytes;
             DisconnectBytes = disconnectBytes;
+            ClientCertificates = clientCertificates;
 
             if (!string.IsNullOrWhiteSpace(token))
             {

--- a/Tcp.NET.Client/Models/ParamsTcpClientBytes.cs
+++ b/Tcp.NET.Client/Models/ParamsTcpClientBytes.cs
@@ -1,6 +1,7 @@
 ﻿using PHS.Networking.Utilities;
 using System;
 using System.Linq;
+using System.Security.Cryptography.X509Certificates;
 using System.Text;
 
 namespace Tcp.NET.Client.Models
@@ -18,8 +19,9 @@ namespace Tcp.NET.Client.Models
         public byte[] Token { get; protected set; }
         public bool UseDisconnectBytes { get; protected set; }
         public byte[] DisconnectBytes { get; protected set; }
+        public X509CertificateCollection ClientCertificates { get; protected set; }
 
-        public ParamsTcpClientBytes(string host, int port, byte[] endOfLineBytes, byte[] token = null, bool isSSL = true, bool onlyEmitBytes = false, bool usePingPong = true, byte[] pingBytes = null, byte[] pongBytes = null, bool useDisconnectBytes = true, byte[] disconnectBytes = null)
+        public ParamsTcpClientBytes(string host, int port, byte[] endOfLineBytes, byte[] token = null, bool isSSL = true, bool onlyEmitBytes = false, bool usePingPong = true, byte[] pingBytes = null, byte[] pongBytes = null, bool useDisconnectBytes = true, byte[] disconnectBytes = null, X509CertificateCollection clientCertificates = null)
         {
             if (string.IsNullOrWhiteSpace(host))
             {
@@ -62,6 +64,7 @@ namespace Tcp.NET.Client.Models
             UseDisconnectBytes = useDisconnectBytes;
             DisconnectBytes = disconnectBytes;
             Token = token;
+            ClientCertificates = clientCertificates;
 
             if (UseDisconnectBytes && (DisconnectBytes == null || Statics.ByteArrayEquals(DisconnectBytes, Array.Empty<byte>())))
             {


### PR DESCRIPTION
Hi, first off thanks for a grate client, have been using it in different settings and works great. Now I'm in a situation where I need to support client certificate on ssl authentication. That is done via "AuthenticateAsClientAsync" on the "SslStream". And I would love to se this supported by your Client. I have done most of the work, assuming you like the code style. In a hope that this can be added. I have also tested it for my scenerio.